### PR TITLE
restore original dev/pass login to match .yml

### DIFF
--- a/create_dev_user
+++ b/create_dev_user
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 SUBDOMAIN="dev"
-PASSWORD="pass"
-ADMIN_PASSWORD="pass"
+# dev passwords must be longer than or equal to 6 characters
+# https://github.com/sverhoeven/docker-cartodb/commit/0da3b53207f9e648d64f82b083f0f4c1c5a031fe
+PASSWORD="password"
+ADMIN_PASSWORD="password"
 EMAIL="dev@localhost"
 
 echo "--- Creating databases"

--- a/create_dev_user
+++ b/create_dev_user
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-SUBDOMAIN="exponent"
-PASSWORD="exponent"
-ADMIN_PASSWORD="exponent"
-EMAIL="exponent@localhost"
+SUBDOMAIN="dev"
+PASSWORD="pass"
+ADMIN_PASSWORD="pass"
+EMAIL="dev@localhost"
 
 echo "--- Creating databases"
 bundle exec rake cartodb:db:setup --trace SUBDOMAIN="${SUBDOMAIN}" \

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PORT=3000
-SUBDOMAIN=exponent
+SUBDOMAIN=dev
 
 echo "127.0.0.1 ${SUBDOMAIN}.cartodb.localhost" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
Seems to have been a mix-up with the original dev/pass login from the parent repo & exponent/exponent login in this repo. The `.ym`l file was not updated so `CartoDB` expects `dev.localhost` (and this is the url that has to be visited to access the page, as detailed in the README).
